### PR TITLE
Add support for thresholds

### DIFF
--- a/datadog-petshop.cabal
+++ b/datadog-petshop.cabal
@@ -30,16 +30,17 @@ executable datadog-petshop
   main-is:             Main.hs
   -- other-modules:
   -- other-extensions:
-  build-depends:       aeson >=0.9 && <0.10,
-                       aeson-pretty >=0.7 && <0.8,
-                       base >=4.8 && <4.9,
+  build-depends:       aeson >=0.9 && <1.0,
+                       aeson-pretty >=0.7 && <1.0,
+                       base >=4.8 && <5.0,
                        bytestring >=0.10 && <0.11,
                        containers >=0.5 && <0.6,
                        directory >=1.2 && <1.3,
                        filepath >=1.4 && <1.5,
                        http-client >=0.4 && <0.5,
                        http-client-tls >=0.2 && <0.3,
-                       optparse-applicative >=0.11 && <0.12,
+                       optparse-applicative >=0.11 && <1.0,
+                       scientific >=0.3 && < 0.4,
                        text >=1.2 && <1.3
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
The datadog API now incorporates warning and alert levels as separate
parameters.
